### PR TITLE
Add stack panels for widget layout

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -1,7 +1,8 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
 }
 
 .dashboard {
@@ -15,4 +16,25 @@
   border: 1px solid #ccc;
   border-radius: 4px;
   text-align: center;
+}
+
+.vertical-stack-panel,
+.horizontal-stack-panel {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.vertical-stack-panel {
+  flex-direction: column;
+}
+
+.horizontal-stack-panel {
+  flex-direction: row;
+}
+
+.vertical-stack-panel > .stack-child,
+.horizontal-stack-panel > .stack-child {
+  flex: 1;
+  display: flex;
 }

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,12 +1,17 @@
-import Dashboard from './components/Dashboard'
+import VerticalStackPanel from './components/VerticalStackPanel'
+import HorizontalStackPanel from './components/HorizontalStackPanel'
+import TimeWidget from './widgets/TimeWidget'
+import TextWidget from './widgets/TextWidget'
 import './App.css'
 
 export default function App() {
-  const widgets = [
-    { type: 'time', props: {} },
-    { type: 'text', props: { text: 'Welcome to the dashboard!' } },
-    { type: 'text', props: { text: 'Enjoy your stay.' } },
-  ]
-
-  return <Dashboard widgets={widgets} />
+  return (
+    <VerticalStackPanel>
+      <TimeWidget />
+      <HorizontalStackPanel>
+        <TextWidget text="Welcome to the dashboard!" />
+        <TextWidget text="Enjoy your stay." />
+      </HorizontalStackPanel>
+    </VerticalStackPanel>
+  )
 }

--- a/dashboard/src/App.test.jsx
+++ b/dashboard/src/App.test.jsx
@@ -5,6 +5,8 @@ import { describe, it, expect } from 'vitest'
 describe('App', () => {
   it('renders widgets', () => {
     render(<App />)
+    expect(screen.getByTestId('vertical-stack')).toBeInTheDocument()
+    expect(screen.getByTestId('horizontal-stack')).toBeInTheDocument()
     expect(screen.getByTestId('time-widget')).toBeInTheDocument()
     const texts = screen.getAllByTestId('text-widget')
     expect(texts.length).toBe(2)

--- a/dashboard/src/components/HorizontalStackPanel.jsx
+++ b/dashboard/src/components/HorizontalStackPanel.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function HorizontalStackPanel({ children }) {
+  return (
+    <div className="horizontal-stack-panel" data-testid="horizontal-stack">
+      {React.Children.map(children, (child, idx) => (
+        <div className="stack-child" key={idx}>
+          {child}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/dashboard/src/components/VerticalStackPanel.jsx
+++ b/dashboard/src/components/VerticalStackPanel.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function VerticalStackPanel({ children }) {
+  return (
+    <div className="vertical-stack-panel" data-testid="vertical-stack">
+      {React.Children.map(children, (child, idx) => (
+        <div className="stack-child" key={idx}>
+          {child}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce VerticalStackPanel and HorizontalStackPanel components
- update App to use the new stack panel layout
- tweak styles for full-screen stack panels
- test stack panel rendering

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68650cff6a44832a9f5f7098317c318f