### PR TITLE
Add alignment props and debug mode

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -38,3 +38,12 @@
   flex: 1;
   display: flex;
 }
+
+.debug .vertical-stack-panel,
+.debug .horizontal-stack-panel {
+  border: 1px dashed #666;
+}
+
+.debug .stack-child {
+  border: 1px dashed red;
+}

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import VerticalStackPanel from './components/VerticalStackPanel'
 import HorizontalStackPanel from './components/HorizontalStackPanel'
 import TimeWidget from './widgets/TimeWidget'
@@ -5,13 +6,34 @@ import TextWidget from './widgets/TextWidget'
 import './App.css'
 
 export default function App() {
+  const [debug, setDebug] = useState(false)
+
   return (
-    <VerticalStackPanel>
-      <TimeWidget />
-      <HorizontalStackPanel>
-        <TextWidget text="Welcome to the dashboard!" />
-        <TextWidget text="Enjoy your stay." />
-      </HorizontalStackPanel>
-    </VerticalStackPanel>
+    <div className={debug ? 'debug' : ''}>
+      <button onClick={() => setDebug((d) => !d)}>Toggle Debug</button>
+      <VerticalStackPanel>
+        <TimeWidget
+          verticalContentAlignment="Top"
+          horizontalContentAlignment="Center"
+        />
+        <HorizontalStackPanel>
+          <TextWidget
+            text="Top Left"
+            verticalContentAlignment="Top"
+            horizontalContentAlignment="Left"
+          />
+          <TextWidget
+            text="Centered"
+            verticalContentAlignment="Center"
+            horizontalContentAlignment="Center"
+          />
+          <TextWidget
+            text="Bottom Right"
+            verticalContentAlignment="Bottom"
+            horizontalContentAlignment="Right"
+          />
+        </HorizontalStackPanel>
+      </VerticalStackPanel>
+    </div>
   )
 }

--- a/dashboard/src/App.test.jsx
+++ b/dashboard/src/App.test.jsx
@@ -9,6 +9,6 @@ describe('App', () => {
     expect(screen.getByTestId('horizontal-stack')).toBeInTheDocument()
     expect(screen.getByTestId('time-widget')).toBeInTheDocument()
     const texts = screen.getAllByTestId('text-widget')
-    expect(texts.length).toBe(2)
+    expect(texts.length).toBe(3)
   })
 })

--- a/dashboard/src/components/HorizontalStackPanel.jsx
+++ b/dashboard/src/components/HorizontalStackPanel.jsx
@@ -1,13 +1,37 @@
 import React from 'react'
 
+const verticalMap = {
+  Top: 'flex-start',
+  Center: 'center',
+  Bottom: 'flex-end',
+}
+
+const horizontalMap = {
+  Left: 'flex-start',
+  Center: 'center',
+  Right: 'flex-end',
+}
+
 export default function HorizontalStackPanel({ children }) {
   return (
     <div className="horizontal-stack-panel" data-testid="horizontal-stack">
-      {React.Children.map(children, (child, idx) => (
-        <div className="stack-child" key={idx}>
-          {child}
-        </div>
-      ))}
+      {React.Children.map(children, (child, idx) => {
+        if (!React.isValidElement(child)) return null
+        const {
+          verticalContentAlignment = 'Top',
+          horizontalContentAlignment = 'Center',
+          ...rest
+        } = child.props
+        const style = {
+          alignItems: verticalMap[verticalContentAlignment],
+          justifyContent: horizontalMap[horizontalContentAlignment],
+        }
+        return (
+          <div className="stack-child" style={style} key={idx}>
+            {React.cloneElement(child, rest)}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/dashboard/src/components/VerticalStackPanel.jsx
+++ b/dashboard/src/components/VerticalStackPanel.jsx
@@ -1,13 +1,37 @@
 import React from 'react'
 
+const verticalMap = {
+  Top: 'flex-start',
+  Center: 'center',
+  Bottom: 'flex-end',
+}
+
+const horizontalMap = {
+  Left: 'flex-start',
+  Center: 'center',
+  Right: 'flex-end',
+}
+
 export default function VerticalStackPanel({ children }) {
   return (
     <div className="vertical-stack-panel" data-testid="vertical-stack">
-      {React.Children.map(children, (child, idx) => (
-        <div className="stack-child" key={idx}>
-          {child}
-        </div>
-      ))}
+      {React.Children.map(children, (child, idx) => {
+        if (!React.isValidElement(child)) return null
+        const {
+          verticalContentAlignment = 'Top',
+          horizontalContentAlignment = 'Center',
+          ...rest
+        } = child.props
+        const style = {
+          justifyContent: verticalMap[verticalContentAlignment],
+          alignItems: horizontalMap[horizontalContentAlignment],
+        }
+        return (
+          <div className="stack-child" style={style} key={idx}>
+            {React.cloneElement(child, rest)}
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add vertical/horizontal alignment logic to stack panel components
- showcase alignments and add debug toggle in the sample App
- update CSS for debug borders
- adjust test for additional widgets

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686518659cc0832a8db3293172dd0d3a