### PR TITLE
Wrap stack children in ContentControl

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -39,6 +39,12 @@
   display: flex;
 }
 
+.content-control {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
 .debug .vertical-stack-panel,
 .debug .horizontal-stack-panel {
   border: 1px dashed #666;

--- a/dashboard/src/App.test.jsx
+++ b/dashboard/src/App.test.jsx
@@ -10,5 +10,17 @@ describe('App', () => {
     expect(screen.getByTestId('time-widget')).toBeInTheDocument()
     const texts = screen.getAllByTestId('text-widget')
     expect(texts.length).toBe(3)
+
+    const timeParent = screen.getByTestId('time-widget').parentElement
+    expect(timeParent).toHaveClass('content-control')
+    expect(timeParent).toHaveStyle({
+      justifyContent: 'flex-start',
+      alignItems: 'center',
+    })
+
+    const [topLeft, centered, bottomRight] = texts.map((t) => t.parentElement)
+    expect(topLeft).toHaveStyle({ justifyContent: 'flex-start', alignItems: 'flex-start' })
+    expect(centered).toHaveStyle({ justifyContent: 'center', alignItems: 'center' })
+    expect(bottomRight).toHaveStyle({ justifyContent: 'flex-end', alignItems: 'flex-end' })
   })
 })

--- a/dashboard/src/components/ContentControl.jsx
+++ b/dashboard/src/components/ContentControl.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+const verticalMap = {
+  Top: 'flex-start',
+  Center: 'center',
+  Bottom: 'flex-end',
+}
+
+const horizontalMap = {
+  Left: 'flex-start',
+  Center: 'center',
+  Right: 'flex-end',
+}
+
+export default function ContentControl({
+  verticalContentAlignment = 'Top',
+  horizontalContentAlignment = 'Center',
+  children,
+  ...rest
+}) {
+  const style = {
+    display: 'flex',
+    justifyContent: verticalMap[verticalContentAlignment],
+    alignItems: horizontalMap[horizontalContentAlignment],
+  }
+  return (
+    <div className="content-control" style={style} {...rest}>
+      {children}
+    </div>
+  )
+}

--- a/dashboard/src/components/HorizontalStackPanel.jsx
+++ b/dashboard/src/components/HorizontalStackPanel.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ContentControl from './ContentControl'
 
 const verticalMap = {
   Top: 'flex-start',
@@ -22,13 +23,14 @@ export default function HorizontalStackPanel({ children }) {
           horizontalContentAlignment = 'Center',
           ...rest
         } = child.props
-        const style = {
-          alignItems: verticalMap[verticalContentAlignment],
-          justifyContent: horizontalMap[horizontalContentAlignment],
-        }
         return (
-          <div className="stack-child" style={style} key={idx}>
-            {React.cloneElement(child, rest)}
+          <div className="stack-child" key={idx}>
+            <ContentControl
+              verticalContentAlignment={verticalContentAlignment}
+              horizontalContentAlignment={horizontalContentAlignment}
+            >
+              {React.cloneElement(child, rest)}
+            </ContentControl>
           </div>
         )
       })}

--- a/dashboard/src/components/VerticalStackPanel.jsx
+++ b/dashboard/src/components/VerticalStackPanel.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ContentControl from './ContentControl'
 
 const verticalMap = {
   Top: 'flex-start',
@@ -22,13 +23,14 @@ export default function VerticalStackPanel({ children }) {
           horizontalContentAlignment = 'Center',
           ...rest
         } = child.props
-        const style = {
-          justifyContent: verticalMap[verticalContentAlignment],
-          alignItems: horizontalMap[horizontalContentAlignment],
-        }
         return (
-          <div className="stack-child" style={style} key={idx}>
-            {React.cloneElement(child, rest)}
+          <div className="stack-child" key={idx}>
+            <ContentControl
+              verticalContentAlignment={verticalContentAlignment}
+              horizontalContentAlignment={horizontalContentAlignment}
+            >
+              {React.cloneElement(child, rest)}
+            </ContentControl>
           </div>
         )
       })}


### PR DESCRIPTION
## Summary
- add a `ContentControl` component that handles alignment styles
- wrap stack panel children in `ContentControl`
- support new `.content-control` class in `App.css`
- test that alignment styles are applied

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68651e0f81b0832a8063162f1c009db1