### PR TITLE
Add debug borders and expand sample layout

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -38,3 +38,7 @@
   flex: 1;
   display: flex;
 }
+
+.debug .stack-child {
+  border: 1px dashed red;
+}

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -5,12 +5,19 @@ import TextWidget from './widgets/TextWidget'
 import './App.css'
 
 export default function App() {
+  const debug = true
+
   return (
-    <VerticalStackPanel>
+    <VerticalStackPanel debug={debug}>
       <TimeWidget />
-      <HorizontalStackPanel>
+      <HorizontalStackPanel debug={debug}>
         <TextWidget text="Welcome to the dashboard!" />
         <TextWidget text="Enjoy your stay." />
+        <TextWidget text="Another example entry." />
+      </HorizontalStackPanel>
+      <HorizontalStackPanel debug={debug}>
+        <TextWidget text="Dashboard rules!" />
+        <TextWidget text="One more widget." />
       </HorizontalStackPanel>
     </VerticalStackPanel>
   )

--- a/dashboard/src/App.test.jsx
+++ b/dashboard/src/App.test.jsx
@@ -6,9 +6,10 @@ describe('App', () => {
   it('renders widgets', () => {
     render(<App />)
     expect(screen.getByTestId('vertical-stack')).toBeInTheDocument()
-    expect(screen.getByTestId('horizontal-stack')).toBeInTheDocument()
+    const stacks = screen.getAllByTestId('horizontal-stack')
+    expect(stacks.length).toBe(2)
     expect(screen.getByTestId('time-widget')).toBeInTheDocument()
     const texts = screen.getAllByTestId('text-widget')
-    expect(texts.length).toBe(2)
+    expect(texts.length).toBe(5)
   })
 })

--- a/dashboard/src/components/HorizontalStackPanel.jsx
+++ b/dashboard/src/components/HorizontalStackPanel.jsx
@@ -1,8 +1,11 @@
 import React from 'react'
 
-export default function HorizontalStackPanel({ children }) {
+export default function HorizontalStackPanel({ children, debug = false }) {
   return (
-    <div className="horizontal-stack-panel" data-testid="horizontal-stack">
+    <div
+      className={`horizontal-stack-panel${debug ? ' debug' : ''}`}
+      data-testid="horizontal-stack"
+    >
       {React.Children.map(children, (child, idx) => (
         <div className="stack-child" key={idx}>
           {child}

--- a/dashboard/src/components/VerticalStackPanel.jsx
+++ b/dashboard/src/components/VerticalStackPanel.jsx
@@ -1,8 +1,11 @@
 import React from 'react'
 
-export default function VerticalStackPanel({ children }) {
+export default function VerticalStackPanel({ children, debug = false }) {
   return (
-    <div className="vertical-stack-panel" data-testid="vertical-stack">
+    <div
+      className={`vertical-stack-panel${debug ? ' debug' : ''}`}
+      data-testid="vertical-stack"
+    >
       {React.Children.map(children, (child, idx) => (
         <div className="stack-child" key={idx}>
           {child}


### PR DESCRIPTION
## Summary
- add `debug` prop to stack panel components
- draw dashed red border in debug mode
- expand the sample App with more widgets
- update tests for new layout

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686525c908cc832a8e95202ad1d6adb8