### PR TITLE
Wrap stack panel children in DashboardTile

### DIFF
--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -54,3 +54,9 @@
 .debug .stack-child {
   border: 1px dashed red;
 }
+
+.dashboard-tile {
+  width: 100%;
+  height: 100%;
+  display: flex;
+}

--- a/dashboard/src/components/DashboardTile.jsx
+++ b/dashboard/src/components/DashboardTile.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export default function DashboardTile({ children }) {
+  return <div className="dashboard-tile">{children}</div>
+}
+

--- a/dashboard/src/components/HorizontalStackPanel.jsx
+++ b/dashboard/src/components/HorizontalStackPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ContentControl from './ContentControl'
+import DashboardTile from './DashboardTile'
 
 const verticalMap = {
   Top: 'flex-start',
@@ -20,7 +21,7 @@ export default function HorizontalStackPanel({ children, debug = false }) {
       data-testid="horizontal-stack">
       {React.Children.map(children, (child, idx) => (
         <div className="stack-child" key={idx}>
-          {child}
+          <DashboardTile>{child}</DashboardTile>
         </div>
       ))}
 

--- a/dashboard/src/components/VerticalStackPanel.jsx
+++ b/dashboard/src/components/VerticalStackPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ContentControl from './ContentControl'
+import DashboardTile from './DashboardTile'
 
 const verticalMap = {
   Top: 'flex-start',
@@ -21,7 +22,7 @@ export default function VerticalStackPanel({ children, debug = false }) {
     >
       {React.Children.map(children, (child, idx) => (
         <div className="stack-child" key={idx}>
-          {child}
+          <DashboardTile>{child}</DashboardTile>
         </div>
       ))}
 


### PR DESCRIPTION
## Summary
- create `DashboardTile` component
- wrap children of `VerticalStackPanel` and `HorizontalStackPanel` inside new tile
- add styles for `.dashboard-tile`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686540b39b88832a9a25ff4311939e8b