### PR TITLE
Add content alignment to DashboardTile

### DIFF
--- a/dashboard/src/DashboardTile.test.jsx
+++ b/dashboard/src/DashboardTile.test.jsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import DashboardTile from './components/DashboardTile'
+
+describe('DashboardTile', () => {
+  it('applies alignment styles', () => {
+    const { container } = render(
+      <DashboardTile verticalContentAlignment="bottom" horizontalContentAlignment="center">
+        <div>Child</div>
+      </DashboardTile>
+    )
+    const tile = container.firstChild
+    expect(tile).toHaveStyle({ justifyContent: 'flex-end', alignItems: 'center' })
+  })
+})

--- a/dashboard/src/components/DashboardTile.jsx
+++ b/dashboard/src/components/DashboardTile.jsx
@@ -1,6 +1,34 @@
 import React from 'react'
 
-export default function DashboardTile({ children }) {
-  return <div className="dashboard-tile">{children}</div>
+const verticalMap = {
+  top: 'flex-start',
+  center: 'center',
+  bottom: 'flex-end',
+}
+
+const horizontalMap = {
+  left: 'flex-start',
+  center: 'center',
+  right: 'flex-end',
+}
+
+export default function DashboardTile({
+  children,
+  verticalContentAlignment,
+  horizontalContentAlignment,
+}) {
+  const style = {}
+  if (verticalContentAlignment) {
+    style.justifyContent = verticalMap[verticalContentAlignment]
+  }
+  if (horizontalContentAlignment) {
+    style.alignItems = horizontalMap[horizontalContentAlignment]
+  }
+
+  return (
+    <div className="dashboard-tile" style={style}>
+      {children}
+    </div>
+  )
 }
 


### PR DESCRIPTION
## Summary
- allow `DashboardTile` to align its children with `verticalContentAlignment` and `horizontalContentAlignment` props
- test content alignment behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686546cc4ed4832ab46005f4e6a8b2cb