### PR TITLE
Add alignment support to widgets

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -10,15 +10,15 @@ export default function App() {
 
   return (
     <VerticalStackPanel debug={debug}>
-      <TimeWidget />
+      <TimeWidget verticalContentAlignment="Center" horizontalContentAlignment="Right" />
       <HorizontalStackPanel debug={debug}>
-        <TextWidget text="Welcome to the dashboard!" />
-        <TextWidget text="Enjoy your stay." />
-        <TextWidget text="Another example entry." />
+        <TextWidget text="Welcome to the dashboard!" verticalContentAlignment="Top" horizontalContentAlignment="Left" />
+        <TextWidget text="Enjoy your stay." verticalContentAlignment="Center" horizontalContentAlignment="Center" />
+        <TextWidget text="Another example entry." verticalContentAlignment="Bottom" horizontalContentAlignment="Right" />
       </HorizontalStackPanel>
       <HorizontalStackPanel debug={debug}>
-        <TextWidget text="Dashboard rules!" />
-        <TextWidget text="One more widget." />
+        <TextWidget text="Dashboard rules!" verticalContentAlignment="Center" horizontalContentAlignment="Left" />
+        <TextWidget text="One more widget." verticalContentAlignment="Center" horizontalContentAlignment="Right" />
       </HorizontalStackPanel>
     </VerticalStackPanel>
 

--- a/dashboard/src/widgets/TextWidget.jsx
+++ b/dashboard/src/widgets/TextWidget.jsx
@@ -1,9 +1,21 @@
 import { useEffect } from 'react'
+import ContentControl from '../components/ContentControl'
 
-export default function TextWidget({ text = '' }) {
+export default function TextWidget({
+  text = '',
+  verticalContentAlignment,
+  horizontalContentAlignment,
+}) {
   useEffect(() => {
     console.log('TextWidget mounted with text:', text)
   }, [text])
 
-  return <div data-testid="text-widget">{text}</div>
+  return (
+    <ContentControl
+      verticalContentAlignment={verticalContentAlignment}
+      horizontalContentAlignment={horizontalContentAlignment}
+    >
+      <div data-testid="text-widget">{text}</div>
+    </ContentControl>
+  )
 }

--- a/dashboard/src/widgets/TextWidget.test.jsx
+++ b/dashboard/src/widgets/TextWidget.test.jsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import TextWidget from './TextWidget'
+
+describe('TextWidget', () => {
+  it('forwards alignment props to ContentControl', () => {
+    const { getByTestId } = render(
+      <TextWidget
+        text="Aligned"
+        verticalContentAlignment="Center"
+        horizontalContentAlignment="Left"
+      />
+    )
+    const wrapper = getByTestId('text-widget').parentElement
+    expect(wrapper).toHaveStyle({ justifyContent: 'center', alignItems: 'flex-start' })
+  })
+})

--- a/dashboard/src/widgets/TimeWidget.jsx
+++ b/dashboard/src/widgets/TimeWidget.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react'
+import ContentControl from '../components/ContentControl'
 
-export default function TimeWidget() {
+export default function TimeWidget({
+  verticalContentAlignment,
+  horizontalContentAlignment,
+}) {
   const [now, setNow] = useState(new Date())
 
   useEffect(() => {
@@ -10,6 +14,11 @@ export default function TimeWidget() {
   }, [])
 
   return (
-    <div data-testid="time-widget">Time: {now.toLocaleString()}</div>
+    <ContentControl
+      verticalContentAlignment={verticalContentAlignment}
+      horizontalContentAlignment={horizontalContentAlignment}
+    >
+      <div data-testid="time-widget">Time: {now.toLocaleString()}</div>
+    </ContentControl>
   )
 }

--- a/dashboard/src/widgets/TimeWidget.test.jsx
+++ b/dashboard/src/widgets/TimeWidget.test.jsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import TimeWidget from './TimeWidget'
+
+describe('TimeWidget', () => {
+  it('forwards alignment props to ContentControl', () => {
+    const { getByTestId } = render(
+      <TimeWidget
+        verticalContentAlignment="Bottom"
+        horizontalContentAlignment="Right"
+      />
+    )
+    const wrapper = getByTestId('time-widget').parentElement
+    expect(wrapper).toHaveStyle({ justifyContent: 'flex-end', alignItems: 'flex-end' })
+  })
+})


### PR DESCRIPTION
## Summary
- forward vertical/horizontal alignment props to TextWidget and TimeWidget via `ContentControl`
- pass alignment values when rendering widgets in `App.jsx`
- test new alignment support for the widgets

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68655e93fb14832aa3add842985da602