### PR TITLE
Add debug backgrounds

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,0 +1,2 @@
+# Set to "true" to enable debug backgrounds
+VITE_DEBUG=false

--- a/dashboard/src/debug.css
+++ b/dashboard/src/debug.css
@@ -1,0 +1,21 @@
+body.debug #root {
+  background-color: rgba(255, 0, 0, 0.2);
+}
+body.debug .logo {
+  background-color: rgba(0, 255, 0, 0.2);
+}
+body.debug h1 {
+  background-color: rgba(0, 0, 255, 0.2);
+}
+body.debug h3 {
+  background-color: rgba(255, 255, 0, 0.2);
+}
+body.debug .card {
+  background-color: rgba(255, 0, 255, 0.2);
+}
+body.debug button {
+  background-color: rgba(0, 255, 255, 0.2);
+}
+body.debug p {
+  background-color: rgba(255, 128, 0, 0.2);
+}

--- a/dashboard/src/main.jsx
+++ b/dashboard/src/main.jsx
@@ -1,7 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './debug.css'
 import App from './App.jsx'
+
+const isDebug = import.meta.env.VITE_DEBUG === 'true'
+if (isDebug && typeof document !== 'undefined') {
+  document.body.classList.add('debug')
+}
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- add CSS for debug background colors
- toggle debug backgrounds using `VITE_DEBUG` flag in main entry
- provide `.env.example` with default setting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866ea1595f8832ab2c90ab461c91042