### PR TITLE
Add debug TestWidget

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,35 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import TestWidget from './TestWidget.jsx'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React blabla </h1>
-      <h3>hallo ;-D</h3>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <TestWidget />
+    </div>
   )
 }
 

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -3,7 +3,7 @@ import TestWidget from './TestWidget.jsx'
 
 function App() {
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+    <div style={{ display: 'flex', width: '100%', height: '100%' }}>
       <TestWidget />
     </div>
   )

--- a/dashboard/src/TestWidget.jsx
+++ b/dashboard/src/TestWidget.jsx
@@ -1,0 +1,28 @@
+import { useMemo } from 'react'
+
+function randomColor() {
+  return '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0')
+}
+
+export default function TestWidget({ size = 200 }) {
+  const color = useMemo(randomColor, [])
+  const style = {
+    border: `1px solid ${color}`,
+    position: 'relative',
+    width: size,
+    height: size,
+  }
+  return (
+    <div style={style}>
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 100 100"
+        style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none' }}
+      >
+        <line x1="0" y1="0" x2="100" y2="100" stroke={color} strokeWidth="1" />
+        <line x1="100" y1="0" x2="0" y2="100" stroke={color} strokeWidth="1" />
+      </svg>
+    </div>
+  )
+}

--- a/dashboard/src/TestWidget.jsx
+++ b/dashboard/src/TestWidget.jsx
@@ -4,13 +4,13 @@ function randomColor() {
   return '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0')
 }
 
-export default function TestWidget({ size = 200 }) {
+export default function TestWidget() {
   const color = useMemo(randomColor, [])
   const style = {
     border: `1px solid ${color}`,
     position: 'relative',
-    width: size,
-    height: size,
+    width: "100%",
+    height: "100%",
   }
   return (
     <div style={style}>


### PR DESCRIPTION
## Summary
- create `TestWidget` component that draws a border and cross with a random color
- simplify `App.jsx` to only show the new debug widget

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866fa453cbc832aa4726591b58fc471