### PR TITLE
Add stack panel layout sample

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,11 +1,19 @@
 import './App.css'
 import TestWidget from './TestWidget.jsx'
+import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
 
 function App() {
   return (
-    <div style={{ display: 'flex', width: '100%', height: '100%' }}>
-      <TestWidget />
-    </div>
+    <VerticalStackPanel>
+      <HorizontalStackPanel style={{ flex: 1 }}>
+        <TestWidget />
+        <TestWidget />
+      </HorizontalStackPanel>
+      <HorizontalStackPanel style={{ flex: 1 }}>
+        <TestWidget />
+        <TestWidget />
+      </HorizontalStackPanel>
+    </VerticalStackPanel>
   )
 }
 

--- a/dashboard/src/StackPanels.jsx
+++ b/dashboard/src/StackPanels.jsx
@@ -1,0 +1,32 @@
+export function VerticalStackPanel({ children, style, ...rest }) {
+  const combinedStyle = {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    width: '100%',
+    height: '100%',
+    ...style,
+  }
+  return (
+    <div style={combinedStyle} {...rest}>
+      {children}
+    </div>
+  )
+}
+
+export function HorizontalStackPanel({ children, style, ...rest }) {
+  const combinedStyle = {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    width: '100%',
+    height: '100%',
+    ...style,
+  }
+  return (
+    <div style={combinedStyle} {...rest}>
+      {children}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `StackPanels` components for vertical and horizontal layout
- update `App` to demonstrate layout with multiple `TestWidget`s

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686822d4fe5c832abb6c256374c75ac6