### PR TITLE
Add DateTime and String widgets

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,13 +1,15 @@
 import './App.css'
 import TestWidget from './TestWidget.jsx'
+import DateTimeWidget from './DateTimeWidget.jsx'
+import StringWidget from './StringWidget.jsx'
 import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
 
 function App() {
   return (
     <VerticalStackPanel>
       <HorizontalStackPanel style={{ flex: 1 }}>
-        <TestWidget />
-        <TestWidget />
+        <DateTimeWidget />
+        <StringWidget text="Hello from StringWidget" />
       </HorizontalStackPanel>
       <HorizontalStackPanel style={{ flex: 1 }}>
         <TestWidget />

--- a/dashboard/src/DateTimeWidget.jsx
+++ b/dashboard/src/DateTimeWidget.jsx
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+
+export default function DateTimeWidget() {
+  const [now, setNow] = useState(new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+  const style = {
+    border: '1px solid #888',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+  }
+  return (
+    <div style={style}>{now.toLocaleString()}</div>
+  )
+}

--- a/dashboard/src/StringWidget.jsx
+++ b/dashboard/src/StringWidget.jsx
@@ -1,0 +1,13 @@
+export default function StringWidget({ text }) {
+  const style = {
+    border: '1px solid #888',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+  }
+  return (
+    <div style={style}>{text}</div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a DateTime widget that refreshes every second
- add a simple String widget
- integrate both widgets into the dashboard app

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68682f4596d8832a8bec08892e05198d