### PR TITLE
Add configurable layout with config page

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.23.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1014,6 +1015,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2468,6 +2478,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve-from": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,27 +1,49 @@
 import './App.css'
+import { Link } from 'react-router-dom'
 import TestWidget from './TestWidget.jsx'
 import DateTimeWidget from './DateTimeWidget.jsx'
 import StringWidget from './StringWidget.jsx'
 import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
+import { loadLayout } from './layout.js'
+
+const widgets = {
+  DateTimeWidget,
+  StringWidget,
+  TestWidget,
+}
+
+function renderNode(node, index) {
+  if (!node) return null
+  if (node.type === 'vertical') {
+    return (
+      <VerticalStackPanel key={index} style={node.style}>
+        {node.children && node.children.map(renderNode)}
+      </VerticalStackPanel>
+    )
+  }
+  if (node.type === 'horizontal') {
+    return (
+      <HorizontalStackPanel key={index} style={node.style}>
+        {node.children && node.children.map(renderNode)}
+      </HorizontalStackPanel>
+    )
+  }
+  if (node.type === 'widget') {
+    const Widget = widgets[node.widget]
+    return Widget ? <Widget key={index} {...node.props} /> : null
+  }
+  return null
+}
 
 function App() {
+  const layout = loadLayout()
   return (
-    <VerticalStackPanel>
-      <HorizontalStackPanel style={{ flex: 1 }}>
-        <DateTimeWidget />
-        <StringWidget text="Hello from StringWidget" />
-      </HorizontalStackPanel>
-      <HorizontalStackPanel style={{ flex: 1 }}>
-        <TestWidget />
-        <TestWidget />
-        <TestWidget />
-      </HorizontalStackPanel>
-      <HorizontalStackPanel style={{ flex: 1 }}>
-        <TestWidget />
-        <TestWidget />
-        <TestWidget />
-      </HorizontalStackPanel>
-    </VerticalStackPanel>
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+      {renderNode(layout)}
+      <div style={{ position: 'absolute', top: 10, right: 10 }}>
+        <Link to="/config">Configure</Link>
+      </div>
+    </div>
   )
 }
 

--- a/dashboard/src/ConfigPage.jsx
+++ b/dashboard/src/ConfigPage.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { loadLayout, saveLayout } from './layout.js'
+import { useNavigate } from 'react-router-dom'
+
+export default function ConfigPage() {
+  const navigate = useNavigate()
+  const [text, setText] = useState(
+    JSON.stringify(loadLayout(), null, 2)
+  )
+
+  function handleSave() {
+    try {
+      const layout = JSON.parse(text)
+      saveLayout(layout)
+      navigate('/')
+    } catch (err) {
+      alert('Invalid JSON: ' + err.message)
+    }
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Configure Layout</h1>
+      <textarea
+        style={{ width: '100%', height: '300px' }}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={handleSave}>Save</button>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/layout.js
+++ b/dashboard/src/layout.js
@@ -1,0 +1,52 @@
+export const defaultLayout = {
+  type: 'vertical',
+  children: [
+    {
+      type: 'horizontal',
+      children: [
+        { type: 'widget', widget: 'DateTimeWidget' },
+        { type: 'widget', widget: 'StringWidget', props: { text: 'Hello from StringWidget' } },
+      ],
+      style: { flex: 1 }
+    },
+    {
+      type: 'horizontal',
+      children: [
+        { type: 'widget', widget: 'TestWidget' },
+        { type: 'widget', widget: 'TestWidget' },
+        { type: 'widget', widget: 'TestWidget' },
+      ],
+      style: { flex: 1 }
+    },
+    {
+      type: 'horizontal',
+      children: [
+        { type: 'widget', widget: 'TestWidget' },
+        { type: 'widget', widget: 'TestWidget' },
+        { type: 'widget', widget: 'TestWidget' },
+      ],
+      style: { flex: 1 }
+    }
+  ]
+}
+
+export function loadLayout() {
+  try {
+    const data = localStorage.getItem('layout')
+    if (data) {
+      return JSON.parse(data)
+    }
+  } catch (err) {
+    console.error('Failed to parse layout from localStorage', err)
+  }
+  return defaultLayout
+}
+
+export function saveLayout(layout) {
+  try {
+    localStorage.setItem('layout', JSON.stringify(layout))
+  } catch (err) {
+    console.error('Failed to save layout', err)
+  }
+}
+

--- a/dashboard/src/main.jsx
+++ b/dashboard/src/main.jsx
@@ -1,10 +1,17 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import ConfigPage from './ConfigPage.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/config" element={<ConfigPage />} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- implement dynamic layout rendering
- add a configuration page that saves layout JSON to `localStorage`
- hook up routing to switch between the dashboard and config page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686833d74bc8832a9334de609aac2def