### PR TITLE
Fix duplicate widget insertion on drop

### DIFF
--- a/dashboard/src/ConfigPage.jsx
+++ b/dashboard/src/ConfigPage.jsx
@@ -65,6 +65,7 @@ export default function ConfigPage() {
 
   function handleDrop(e, path, index) {
     e.preventDefault()
+    e.stopPropagation()
     const item = JSON.parse(e.dataTransfer.getData('application/json'))
     setLayout((old) => {
       const panelPath = path


### PR DESCRIPTION
## Summary
- stop drop event bubbling when widgets are inserted

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68698f42dc8c832aae8d0045559ca061