### PR TITLE
Add color and size config options for widgets

### DIFF
--- a/dashboard/src/ConfigPage.jsx
+++ b/dashboard/src/ConfigPage.jsx
@@ -113,8 +113,46 @@ export default function ConfigPage() {
         if (node.type === 'widget') {
           if (node.widget === 'StringWidget') {
             const text = prompt('Enter text', node.props?.text || '')
-            if (text !== null) {
-              return { ...node, props: { text } }
+            if (text === null) return node
+            const fontSize = prompt(
+              'Font size',
+              node.props?.fontSize || '1rem',
+            )
+            if (fontSize === null) return node
+            const textColor = prompt(
+              'Text color',
+              node.props?.textColor || 'blue',
+            )
+            if (textColor === null) return node
+            const backgroundColor = prompt(
+              'Background color',
+              node.props?.backgroundColor || 'yellow',
+            )
+            if (backgroundColor === null) return node
+            return {
+              ...node,
+              props: { text, fontSize, textColor, backgroundColor },
+            }
+          }
+          if (node.widget === 'DateTimeWidget') {
+            const fontSize = prompt(
+              'Font size',
+              node.props?.fontSize || '1rem',
+            )
+            if (fontSize === null) return node
+            const textColor = prompt(
+              'Text color',
+              node.props?.textColor || 'green',
+            )
+            if (textColor === null) return node
+            const backgroundColor = prompt(
+              'Background color',
+              node.props?.backgroundColor || 'red',
+            )
+            if (backgroundColor === null) return node
+            return {
+              ...node,
+              props: { fontSize, textColor, backgroundColor },
             }
           }
           return node

--- a/dashboard/src/StringWidget.jsx
+++ b/dashboard/src/StringWidget.jsx
@@ -1,14 +1,19 @@
-export default function StringWidget({ text }) {
+export default function StringWidget({
+  text,
+  fontSize = '1rem',
+  textColor = 'blue',
+  backgroundColor = 'yellow',
+} = {}) {
   const style = {
     border: '1px solid #888',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    
-    color: 'blue',
-    backgroundColor: 'yellow',
+    color: textColor,
+    backgroundColor,
+    fontSize,
     width: '100%',
-    height: '100%'
+    height: '100%',
   }
   return (
     <div style={style}>{text}</div>


### PR DESCRIPTION
## Summary
- allow StringWidget to accept fontSize, textColor and backgroundColor props
- extend ConfigPage settings UI to configure those style props on StringWidget and DateTimeWidget

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686995ca4dcc832a83f799ce826de43e