### PR TITLE
Disable widget borders in primary display

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -30,7 +30,7 @@ function renderNode(node, index) {
   }
   if (node.type === 'widget') {
     const Widget = widgets[node.widget]
-    return Widget ? <Widget key={index} {...node.props} /> : null
+    return Widget ? <Widget key={index} showBorder={false} {...node.props} /> : null
   }
   return null
 }

--- a/dashboard/src/DateTimeWidget.jsx
+++ b/dashboard/src/DateTimeWidget.jsx
@@ -4,6 +4,7 @@ export default function DateTimeWidget({
   fontSize = '1rem',
   textColor = 'green',
   backgroundColor = 'red',
+  showBorder = true,
 } = {}) {
   const [now, setNow] = useState(new Date())
   useEffect(() => {
@@ -11,7 +12,7 @@ export default function DateTimeWidget({
     return () => clearInterval(id)
   }, [])
   const style = {
-    border: '1px solid #888',
+    border: showBorder ? '1px solid #888' : 'none',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/dashboard/src/StringWidget.jsx
+++ b/dashboard/src/StringWidget.jsx
@@ -3,9 +3,10 @@ export default function StringWidget({
   fontSize = '1rem',
   textColor = 'blue',
   backgroundColor = 'yellow',
+  showBorder = true,
 } = {}) {
   const style = {
-    border: '1px solid #888',
+    border: showBorder ? '1px solid #888' : 'none',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/dashboard/src/TestWidget.jsx
+++ b/dashboard/src/TestWidget.jsx
@@ -4,10 +4,10 @@ function randomColor() {
   return '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0')
 }
 
-export default function TestWidget() {
+export default function TestWidget({ showBorder = true } = {}) {
   const color = useMemo(randomColor, [])
   const style = {
-    border: `1px solid ${color}`,
+    border: showBorder ? `1px solid ${color}` : 'none',
     position: 'relative',
     width: "100%",
     height: "100%",


### PR DESCRIPTION
## Summary
- hide borders on widgets for the main display page
- keep borders by default for configuration page usage

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686997ddbd94832aac23b335068036be