### PR TITLE
Add host IP injection scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # MyDashboard
+
+This project contains a small React dashboard served from a Docker container.
+
+Two helper scripts are provided to build and run the container while injecting
+the host's public IP address via the `PUBLIC_IP` environment variable.
+
+## Usage
+
+### Linux
+
+```sh
+./start_dashboard.sh
+```
+
+### Windows
+
+```bat
+start_dashboard.bat
+```
+
+Each script queries the public IP with `curl`, builds the Docker image and runs
+the container with the retrieved IP. The application displays the IP inside the
+"Configure" link.
+

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -10,5 +10,7 @@ FROM nginx:alpine
 WORKDIR /usr/share/nginx/html
 COPY --from=build /app/dist .
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/docker-entrypoint.sh"]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -9,16 +9,14 @@ Currently, two official plugins are available:
 
 ## Running in Docker
 
-To build and run this app in Docker:
+To build and run this app in Docker use the scripts in the project root:
 
 ```sh
-# Build the Docker image
-docker build -t dashboard .
-
-# Run the container (serves on http://localhost:8080)
-docker run -p 8080:80 dashboard
+../start_dashboard.sh
 ```
 
+On Windows run `start_dashboard.bat`. These scripts build the image, obtain your
+public IP address and run the container with that value passed as `PUBLIC_IP`.
 Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
 ## Expanding the ESLint configuration

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+: "${PUBLIC_IP:=}"
+echo "window.PUBLIC_IP='${PUBLIC_IP}'" > /usr/share/nginx/html/env.js
+exec nginx -g 'daemon off;'

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/env.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -37,11 +37,12 @@ function renderNode(node, index) {
 
 function App() {
   const layout = loadLayout()
+  const ip = window.PUBLIC_IP || 'unknown'
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
       {renderNode(layout)}
       <div style={{ position: 'absolute', top: 10, right: 10 }}>
-        <Link to="/config">Configure</Link>
+        <Link to="/config">{`Configure (${ip})`}</Link>
       </div>
     </div>
   )

--- a/start_dashboard.bat
+++ b/start_dashboard.bat
@@ -1,0 +1,19 @@
+
+@echo off
+
+set IMAGE_NAME=dashboard
+
+set SCRIPT_DIR=%~dp0dashboard
+
+REM Build the image
+
+docker build -t %IMAGE_NAME% %SCRIPT_DIR%
+
+REM Obtain public IP
+
+for /f "usebackq delims=" %%i in (`curl -s https://api.ipify.org`) do set PUBLIC_IP=%%i
+
+REM Run the container
+
+docker run -p 8080:80 -e PUBLIC_IP=%PUBLIC_IP% %IMAGE_NAME%
+

--- a/start_dashboard.sh
+++ b/start_dashboard.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Build and run the dashboard container with PUBLIC_IP env variable
+set -e
+IMAGE_NAME=dashboard
+SCRIPT_DIR="$(dirname "$0")/dashboard"
+# Build image if not already built
+docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
+# Obtain public IP
+PUBLIC_IP=$(curl -s https://api.ipify.org)
+# Run container with IP env var
+exec docker run -p 8080:80 -e PUBLIC_IP="$PUBLIC_IP" "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- add scripts for Linux and Windows to fetch the host IP and run the container
- inject `PUBLIC_IP` into the running container via a new entrypoint
- show the IP in the `Configure` link
- document the new workflow

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68699bab4894832ab52d69463c8e1c38