### PR TITLE
Add Windows start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # MyDashboard
+
+This repository contains a simple React dashboard served with Vite.
+
+Use `./start.sh` on Unix-like systems or `start.ps1` or `start.bat` on Windows to run the development server. These scripts print the local network IP address before launching Vite so you can access the dashboard from other devices on the same network.

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "IP="
+for /f "tokens=2 delims=:" %%f in ('ipconfig ^| findstr /R /C:"IPv4 Address"') do (
+    for /f "delims= " %%g in ("%%f") do (
+        set IP=%%g
+        if not "!IP:~0,3!"=="169" if not "!IP:~0,3!"=="127" goto :found
+    )
+)
+:found
+if defined IP (
+    echo Local network IP: !IP!
+) else (
+    echo Could not determine local IP address
+)
+
+npm --prefix dashboard run dev
+endlocal
+

--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+
+# Try to determine local network IP address
+$localIp = $(ipconfig | Select-String -Pattern 'IPv4 Address.*: ([0-9\.]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value } | Select-Object -First 1)
+if (-not $localIp) {
+  $localIp = Get-NetIPAddress -AddressFamily IPv4 | Where-Object { $_.IPAddress -notmatch '^169\.254' -and $_.IPAddress -ne '127.0.0.1' } | Select-Object -First 1 -ExpandProperty IPAddress
+}
+if ($localIp) {
+  Write-Host "Local network IP: $localIp"
+} else {
+  Write-Host "Could not determine local IP address"
+}
+
+# Start the Vite dev server inside the dashboard directory
+npm --prefix dashboard run dev
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Print local network IP address
+local_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+if [ -z "$local_ip" ]; then
+  local_ip=$(ip addr show 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v '^127' | head -n1)
+fi
+if [ -n "$local_ip" ]; then
+  echo "Local network IP: $local_ip"
+else
+  echo "Could not determine local IP address"
+fi
+
+# Start the Vite dev server inside the dashboard directory
+npm --prefix dashboard run dev
+


### PR DESCRIPTION
## Summary
- create `start.ps1` to launch the dev server on Windows and print the local IP
- add Windows batch script `start.bat` with the same IP detection
- document the scripts in README

## Testing
- `npm --prefix dashboard test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6869a49049e8832aa6b7abb4bcecf2dc