### PR TITLE
Add backend server and refactor MailWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # MyDashboard
 
 This project contains a small React dashboard served from a Docker container.
+The application now includes a tiny Node.js backend which performs the OAuth
+device-code flow and fetches e‑mails from Microsoft Graph. This backend avoids
+CORS issues by handling the authentication server-side.
 
 Two helper scripts are provided to build and run the container while injecting
 the host's public IP address via the `PUBLIC_IP` environment variable.

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,16 +1,19 @@
-# Dockerfile for React (Vite) App
+# Dockerfile for React app with backend
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install
 COPY . .
-RUN npm install && npm run build
+RUN npm run build && cd backend && npm install --production
 
 # Production stage
-FROM nginx:alpine
-WORKDIR /usr/share/nginx/html
-COPY --from=build /app/dist .
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
-COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/backend ./backend
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
+ENV PORT=80
 EXPOSE 80
 CMD ["/docker-entrypoint.sh"]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,6 +1,8 @@
 # React + Vite
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.  
+The Docker image also contains a small Express server used to perform OAuth requests
+to Microsoft Graph on behalf of the frontend.
 
 Currently, two official plugins are available:
 

--- a/dashboard/backend/package.json
+++ b/dashboard/backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mail-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/dashboard/backend/server.js
+++ b/dashboard/backend/server.js
@@ -1,0 +1,88 @@
+import express from 'express'
+import fetch from 'node-fetch'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const app = express()
+app.use(express.json())
+
+const tokens = new Map()
+
+app.post('/api/device-code', async (req, res) => {
+  const { clientId, tenant = 'common', scopes } = req.body || {}
+  if (!clientId) return res.status(400).json({ error: 'clientId required' })
+  try {
+    const params = new URLSearchParams()
+    params.append('client_id', clientId)
+    params.append('scope', scopes)
+    const resp = await fetch(`https://login.microsoftonline.com/${tenant}/oauth2/v2.0/devicecode`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    })
+    const data = await resp.json()
+    if (!resp.ok) return res.status(400).json({ error: data.error_description || 'Failed to obtain device code' })
+    tokens.set(clientId, { device_code: data.device_code, interval: data.interval * 1000 })
+    res.json({ verification_uri: data.verification_uri, user_code: data.user_code })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+app.post('/api/poll-token', async (req, res) => {
+  const { clientId, tenant = 'common' } = req.body || {}
+  const entry = tokens.get(clientId)
+  if (!entry) return res.status(400).json({ error: 'No device code. Start auth first.' })
+  try {
+    const params = new URLSearchParams()
+    params.append('grant_type', 'urn:ietf:params:oauth:grant-type:device_code')
+    params.append('client_id', clientId)
+    params.append('device_code', entry.device_code)
+    const resp = await fetch(`https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    })
+    const data = await resp.json()
+    if (resp.ok) {
+      entry.access_token = data.access_token
+      entry.expires_at = Date.now() + data.expires_in * 1000
+      return res.json({ success: true })
+    }
+    if (data.error === 'authorization_pending') return res.json({ pending: true })
+    res.status(400).json({ error: data.error_description || 'Failed to obtain token' })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+app.get('/api/messages', async (req, res) => {
+  const { clientId, numMessages = 5 } = req.query
+  const entry = tokens.get(clientId)
+  if (!entry || !entry.access_token || entry.expires_at <= Date.now()) {
+    return res.status(401).json({ error: 'No valid token. Authenticate first.' })
+  }
+  try {
+    const resp = await fetch(`https://graph.microsoft.com/v1.0/me/messages?$top=${numMessages}`, {
+      headers: { Authorization: `Bearer ${entry.access_token}` },
+    })
+    const data = await resp.json()
+    if (!resp.ok) return res.status(400).json({ error: data.error?.message || 'Failed to load messages' })
+    res.json(data.value)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// Serve static files
+const distPath = path.join(__dirname, '../dist')
+app.use(express.static(distPath))
+app.get('*', (req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'))
+})
+
+const port = process.env.PORT || 80
+app.listen(port, () => console.log(`Server listening on port ${port}`))

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 : "${PUBLIC_IP:=}"
-echo "window.PUBLIC_IP='${PUBLIC_IP}'" > /usr/share/nginx/html/env.js
-exec nginx -g 'daemon off;'
+echo "window.PUBLIC_IP='${PUBLIC_IP}'" > /app/dist/env.js
+exec node /app/backend/server.js

--- a/dashboard/eslint.config.js
+++ b/dashboard/eslint.config.js
@@ -26,4 +26,10 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  {
+    files: ['backend/**/*.js'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
 ])


### PR DESCRIPTION
## Summary
- implement Express backend to perform OAuth and fetch messages
- serve static files and API from new Node server
- update MailWidget to use backend endpoints
- switch Docker image to Node runtime
- document backend changes and lint rules

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a4eecdc84832a824a2d188db74411