### PR TITLE
Add backend test endpoint and frontend logging

### DIFF
--- a/dashboard/backend/server.js
+++ b/dashboard/backend/server.js
@@ -9,6 +9,10 @@ const __dirname = path.dirname(__filename)
 const app = express()
 app.use(express.json())
 
+app.get('/api/test', (req, res) => {
+  res.json({ ok: true })
+})
+
 const tokens = new Map()
 
 app.post('/api/device-code', async (req, res) => {


### PR DESCRIPTION
## Summary
- add `/api/test` endpoint to backend
- verify server connectivity in MailWidget before fetching messages
- log steps in MailWidget for easier debugging

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a6242d82c832ab97abd70aa067faf