### PR TITLE
Fix Windows npm prefix usage

### DIFF
--- a/start_dashboard.bat
+++ b/start_dashboard.bat
@@ -8,8 +8,8 @@ REM Build the image
 docker build -t %IMAGE_NAME% %SCRIPT_DIR%
 
 REM Ensure backend dependencies and start server in new window
-npm install --prefix server >nul
-start "backend" cmd /c "npm start --prefix server"
+npm --prefix server install >nul
+start "backend" cmd /c "npm --prefix server start"
 
 REM Obtain public IP
 for /f "usebackq delims=" %%i in (`curl -s https://api.ipify.org`) do set PUBLIC_IP=%%i


### PR DESCRIPTION
## Summary
- fix npm command syntax in `start_dashboard.bat`

## Testing
- `npm --prefix dashboard install`
- `npm --prefix dashboard run build`
- `npm --prefix server install`


------
https://chatgpt.com/codex/tasks/task_e_686a7ef3bdfc832a962f3fbe9b78ec5e