### PR TITLE
Add Windows backend runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ To start both the dashboard and backend simultaneously run:
 
 The dashboard will be available on [http://localhost:8080](http://localhost:8080)
 and the backend on [http://localhost:3000/test](http://localhost:3000/test).
+
+### Windows
+
+To run only the backend on Windows use:
+
+```bat
+start_backend.bat
+```
+
+The script builds the `backend` image if it does not exist and then runs the
+container exposing port `3000`.

--- a/start_backend.bat
+++ b/start_backend.bat
@@ -1,0 +1,14 @@
+@echo off
+
+set IMAGE_NAME=backend
+set SCRIPT_DIR=%~dp0backend
+
+REM Build image if it does not exist
+docker image inspect %IMAGE_NAME% >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    docker build -t %IMAGE_NAME% %SCRIPT_DIR%
+)
+
+REM Run the container
+docker run -p 3000:3000 %IMAGE_NAME%
+


### PR DESCRIPTION
## Summary
- add `start_backend.bat` script to run the backend on Windows
- update README with Windows instructions for running the backend

## Testing
- `npm run lint` in `dashboard`
- `npm test` in `backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c17142794832a84c672f37571ac32