### PR TITLE
Add start_services.bat for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ and the backend on [http://localhost:3000/test](http://localhost:3000/test).
 
 ### Windows
 
+To start both the dashboard and backend on Windows run:
+
+```bat
+start_services.bat
+```
+
 To run only the backend on Windows use:
 
 ```bat

--- a/start_services.bat
+++ b/start_services.bat
@@ -1,0 +1,7 @@
+@echo off
+
+for /f "usebackq delims=" %%i in (`curl -s https://api.ipify.org`) do set PUBLIC_IP=%%i
+
+REM Build and run containers
+
+docker compose up --build


### PR DESCRIPTION
## Summary
- add a Windows batch script `start_services.bat` that runs Docker Compose
- document how to start both services on Windows in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c1a50b428832a92b5e7933931eb5a