### PR TITLE
Add backend test widget

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,10 @@
 const express = require('express');
 const app = express();
 const PORT = 3000;
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  next();
+});
 app.get('/test', (req, res) => {
   res.json({ message: 'Backend is running' });
 });

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import TestWidget from './TestWidget.jsx'
 import DateTimeWidget from './DateTimeWidget.jsx'
 import StringWidget from './StringWidget.jsx'
+import BackendTestWidget from './BackendTestWidget.jsx'
 import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
 import { loadLayout } from './layout.js'
 
@@ -10,6 +11,7 @@ const widgets = {
   DateTimeWidget,
   StringWidget,
   TestWidget,
+  BackendTestWidget,
 }
 
 function renderNode(node, index) {

--- a/dashboard/src/BackendTestWidget.jsx
+++ b/dashboard/src/BackendTestWidget.jsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react'
+
+export default function BackendTestWidget({
+  endpoint = '/test',
+  refreshInterval = 5000,
+  showBorder = true,
+} = {}) {
+  const [message, setMessage] = useState('Loading...')
+  useEffect(() => {
+    let cancelled = false
+    async function fetchData() {
+      try {
+        const res = await fetch(endpoint)
+        const data = await res.json()
+        if (!cancelled) {
+          setMessage(data.message ?? JSON.stringify(data))
+        }
+      } catch {
+        if (!cancelled) setMessage('Failed to fetch')
+      }
+    }
+    fetchData()
+    const id = setInterval(fetchData, refreshInterval)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [endpoint, refreshInterval])
+
+  const style = {
+    border: showBorder ? '1px solid #888' : 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+  }
+
+  return <div style={style}>{message}</div>
+}

--- a/dashboard/src/ConfigPage.jsx
+++ b/dashboard/src/ConfigPage.jsx
@@ -5,8 +5,9 @@ import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
 import DateTimeWidget from './DateTimeWidget.jsx'
 import StringWidget from './StringWidget.jsx'
 import TestWidget from './TestWidget.jsx'
+import BackendTestWidget from './BackendTestWidget.jsx'
 
-const widgets = { DateTimeWidget, StringWidget, TestWidget }
+const widgets = { DateTimeWidget, StringWidget, TestWidget, BackendTestWidget }
 
 const palette = [
   { label: 'Vertical Stack', data: { type: 'vertical', children: [] } },
@@ -14,6 +15,7 @@ const palette = [
   { label: 'DateTimeWidget', data: { type: 'widget', widget: 'DateTimeWidget' } },
   { label: 'StringWidget', data: { type: 'widget', widget: 'StringWidget', props: { text: '' } } },
   { label: 'TestWidget', data: { type: 'widget', widget: 'TestWidget' } },
+  { label: 'BackendTestWidget', data: { type: 'widget', widget: 'BackendTestWidget' } },
 ]
 
 function getNode(layout, path) {

--- a/dashboard/src/layout.js
+++ b/dashboard/src/layout.js
@@ -6,6 +6,7 @@ export const defaultLayout = {
       children: [
         { type: 'widget', widget: 'DateTimeWidget' },
         { type: 'widget', widget: 'StringWidget', props: { text: 'Hello from StringWidget' } },
+        { type: 'widget', widget: 'BackendTestWidget' },
       ],
       style: { flex: 1 }
     },


### PR DESCRIPTION
## Summary
- add CORS headers to the backend
- create `BackendTestWidget` that fetches `/test`
- register the new widget in the dashboard
- include the widget in the palette and default layout

## Testing
- `npm install` in `dashboard`
- `npm run lint` in `dashboard`
- `npm install` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_686c29207bd8832a913e95afe41f9c2d