### PR TITLE
Split app into frontend and backend with docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # MyDashboard
 
-This project contains a small React dashboard served from a Docker container.
-
-Two helper scripts are provided to build and run the container while injecting
-the host's public IP address via the `PUBLIC_IP` environment variable.
+This project now consists of a React frontend and a small Express backend.
+Both services are built with Docker and orchestrated via `docker-compose`.
+The helper scripts start the compose stack while injecting the host's public IP
+address via the `PUBLIC_IP` environment variable.
 
 ## Usage
 
@@ -19,7 +19,9 @@ the host's public IP address via the `PUBLIC_IP` environment variable.
 start_dashboard.bat
 ```
 
-Each script queries the public IP with `curl`, builds the Docker image and runs
-the container with the retrieved IP. The application displays the IP inside the
-"Configure" link.
+Each script queries the public IP with `curl` and then runs `docker compose`
+to build and start both containers. The frontend is available on
+[http://localhost:8080](http://localhost:8080) and the backend on
+[http://localhost:3000](http://localhost:3000). The current IP is displayed in
+the "Configure" link.
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev && npm cache clean --force
+COPY . .
+EXPOSE 3000
+CMD ["npm","start"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,16 @@
+import express from 'express';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/api/public-ip', (req, res) => {
+  res.json({ ip: process.env.PUBLIC_IP || 'unknown' });
+});
+
+app.get('/', (req, res) => {
+  res.send('Backend running');
+});
+
+app.listen(PORT, () => {
+  console.log(`Backend listening on ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "backend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -7,17 +7,18 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
-## Running in Docker
+## Running with Docker Compose
 
-To build and run this app in Docker use the scripts in the project root:
+Use the scripts in the project root to start the full stack using
+`docker-compose`:
 
 ```sh
 ../start_dashboard.sh
 ```
 
-On Windows run `start_dashboard.bat`. These scripts build the image, obtain your
-public IP address and run the container with that value passed as `PUBLIC_IP`.
-Then open [http://localhost:8080](http://localhost:8080) in your browser.
+On Windows run `start_dashboard.bat`. The scripts will build both the frontend
+and backend images, inject your public IP address and launch the containers.
+Open [http://localhost:8080](http://localhost:8080) to view the dashboard.
 
 ## Expanding the ESLint configuration
 

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -7,4 +7,8 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
+
+    location /api/ {
+        proxy_pass http://backend:3000/;
+    }
 }

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,5 +1,6 @@
 import './App.css'
 import { Link } from 'react-router-dom'
+import { useState, useEffect } from 'react'
 import TestWidget from './TestWidget.jsx'
 import DateTimeWidget from './DateTimeWidget.jsx'
 import StringWidget from './StringWidget.jsx'
@@ -38,11 +39,19 @@ function renderNode(node, index) {
 function App() {
   const layout = loadLayout()
   const ip = window.PUBLIC_IP || 'unknown'
+  const [backendIp, setBackendIp] = useState('...')
+
+  useEffect(() => {
+    fetch('/api/public-ip')
+      .then((r) => r.json())
+      .then((d) => setBackendIp(d.ip))
+      .catch(() => setBackendIp('error'))
+  }, [])
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
       {renderNode(layout)}
       <div style={{ position: 'absolute', top: 10, right: 10 }}>
-        <Link to="/config">{`Configure (${ip})`}</Link>
+        <Link to="/config">{`Configure (${ip} / ${backendIp})`}</Link>
       </div>
     </div>
   )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  frontend:
+    build: ./dashboard
+    environment:
+      - PUBLIC_IP=${PUBLIC_IP}
+    ports:
+      - "8080:80"
+    depends_on:
+      - backend
+  backend:
+    build: ./backend
+    environment:
+      - PUBLIC_IP=${PUBLIC_IP}
+    ports:
+      - "3000:3000"

--- a/start_dashboard.bat
+++ b/start_dashboard.bat
@@ -1,19 +1,9 @@
 
 @echo off
 
-set IMAGE_NAME=dashboard
-
-set SCRIPT_DIR=%~dp0dashboard
-
-REM Build the image
-
-docker build -t %IMAGE_NAME% %SCRIPT_DIR%
-
 REM Obtain public IP
-
 for /f "usebackq delims=" %%i in (`curl -s https://api.ipify.org`) do set PUBLIC_IP=%%i
 
-REM Run the container
-
-docker run -p 8080:80 -e PUBLIC_IP=%PUBLIC_IP% %IMAGE_NAME%
+set PUBLIC_IP=%PUBLIC_IP%
+docker compose up --build
 

--- a/start_dashboard.sh
+++ b/start_dashboard.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
-# Build and run the dashboard container with PUBLIC_IP env variable
+# Start the compose stack with PUBLIC_IP env variable
 set -e
-IMAGE_NAME=dashboard
-SCRIPT_DIR="$(dirname "$0")/dashboard"
-# Build image if not already built
-docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
 # Obtain public IP
 PUBLIC_IP=$(curl -s https://api.ipify.org)
-# Run container with IP env var
-exec docker run -p 8080:80 -e PUBLIC_IP="$PUBLIC_IP" "$IMAGE_NAME"
+export PUBLIC_IP
+exec docker compose up --build


### PR DESCRIPTION
## Summary
- add Express backend service
- set up docker-compose for frontend and backend
- proxy `/api` requests from nginx to backend
- fetch backend IP from React frontend
- update start scripts and docs for compose usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c465507c4832ab51e6fa0c291611f