### PR TITLE
Add backend test widget

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -2,6 +2,7 @@ import './App.css'
 import { Link } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import TestWidget from './TestWidget.jsx'
+import BackendTestWidget from './BackendTestWidget.jsx'
 import DateTimeWidget from './DateTimeWidget.jsx'
 import StringWidget from './StringWidget.jsx'
 import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
@@ -10,6 +11,7 @@ import { loadLayout } from './layout.js'
 const widgets = {
   DateTimeWidget,
   StringWidget,
+  BackendTestWidget,
   TestWidget,
 }
 

--- a/dashboard/src/BackendTestWidget.jsx
+++ b/dashboard/src/BackendTestWidget.jsx
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+
+export default function BackendTestWidget({ showBorder = true } = {}) {
+  const [status, setStatus] = useState('loading...')
+  useEffect(() => {
+    fetch('/api/public-ip')
+      .then((r) => r.json())
+      .then((d) => setStatus(`Backend IP: ${d.ip}`))
+      .catch(() => setStatus('error'))
+  }, [])
+  const style = {
+    border: showBorder ? '1px solid #888' : 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+  }
+  return <div style={style}>{status}</div>
+}

--- a/dashboard/src/ConfigPage.jsx
+++ b/dashboard/src/ConfigPage.jsx
@@ -5,8 +5,9 @@ import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
 import DateTimeWidget from './DateTimeWidget.jsx'
 import StringWidget from './StringWidget.jsx'
 import TestWidget from './TestWidget.jsx'
+import BackendTestWidget from './BackendTestWidget.jsx'
 
-const widgets = { DateTimeWidget, StringWidget, TestWidget }
+const widgets = { DateTimeWidget, StringWidget, TestWidget, BackendTestWidget }
 
 const palette = [
   { label: 'Vertical Stack', data: { type: 'vertical', children: [] } },
@@ -14,6 +15,7 @@ const palette = [
   { label: 'DateTimeWidget', data: { type: 'widget', widget: 'DateTimeWidget' } },
   { label: 'StringWidget', data: { type: 'widget', widget: 'StringWidget', props: { text: '' } } },
   { label: 'TestWidget', data: { type: 'widget', widget: 'TestWidget' } },
+  { label: 'BackendTestWidget', data: { type: 'widget', widget: 'BackendTestWidget' } },
 ]
 
 function getNode(layout, path) {


### PR DESCRIPTION
## Summary
- add BackendTestWidget that fetches /api/public-ip
- expose widget in App and ConfigPage so it can be added to layouts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cdee21c88832a8af17159a16600fb