### PR TITLE
Add .env sample and docs for env vars

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Copy this file to ".env" and provide the required values
+# Azure AD application credentials for the backend
+MSAL_CLIENT_ID=
+MSAL_TENANT_ID=
+
+# Optionally set the public IP used by Docker Compose
+# PUBLIC_IP=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ to build and start both containers. The frontend is available on
 [http://localhost:3000](http://localhost:3000). The current IP is displayed in
 the "Configure" link.
 
+### Configuration
+
+Docker Compose loads variables from a file named `.env` in this directory.
+Copy `\.env.sample` to `.env` and fill in your `MSAL_CLIENT_ID` and
+`MSAL_TENANT_ID` values for the Azure AD app registration. The start scripts
+already set `PUBLIC_IP` automatically, but you can override it in `.env` if
+needed. The `.env` file is ignored by Git so your credentials remain local.
+


### PR DESCRIPTION
## Summary
- add `.env.sample` as a template for MSAL variables
- ignore real `.env` in git
- document environment variable setup in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cf98e14f4832a95e5268bbbfff1f3