### PR TITLE
Update compose env vars for MSAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,7 @@ Docker Compose loads variables from a file named `.env` in this directory.
 Copy `\.env.sample` to `.env` and fill in your `MSAL_CLIENT_ID` and
 `MSAL_TENANT_ID` values for the Azure AD app registration. The start scripts
 already set `PUBLIC_IP` automatically, but you can override it in `.env` if
-needed. The `.env` file is ignored by Git so your credentials remain local.
+needed. These MSAL values are forwarded to the backend container when the stack
+starts so it can authenticate with Azure AD. The `.env` file is ignored by Git
+so your credentials remain local.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,7 @@ services:
     build: ./backend
     environment:
       - PUBLIC_IP=${PUBLIC_IP}
+      - MSAL_CLIENT_ID=${MSAL_CLIENT_ID}
+      - MSAL_TENANT_ID=${MSAL_TENANT_ID}
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- forward Azure AD MSAL env vars to the backend in `docker-compose.yml`
- document MSAL vars in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d49791230832aa5896c3ae8c65103