### PR TITLE
Improve env validation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Docker Compose loads variables from a file named `.env` in this directory.
 Copy `\.env.sample` to `.env` and fill in your `MSAL_CLIENT_ID` and
 `MSAL_TENANT_ID` values for the Azure AD app registration. The start scripts
 already set `PUBLIC_IP` automatically, but you can override it in `.env` if
-needed. These MSAL values are forwarded to the backend container when the stack
-starts so it can authenticate with Azure AD. The `.env` file is ignored by Git
-so your credentials remain local.
+needed. Be sure there are **no spaces** around the `=` sign when defining the
+variables. These MSAL values are forwarded to the backend container when the
+stack starts so it can authenticate with Azure AD. The `.env` file is ignored
+by Git so your credentials remain local.
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,19 @@ import express from 'express'
 // fetch is available in Node 20
 import { PublicClientApplication } from '@azure/msal-node'
 
+const requiredVars = ['MSAL_CLIENT_ID', 'MSAL_TENANT_ID']
+for (const name of requiredVars) {
+  const value = process.env[name]
+  if (!value) {
+    console.warn(
+      `Environment variable ${name} is not set. Did you configure it in the .env file?`
+    )
+  } else if (value.trim() !== value) {
+    console.warn(`Trimming whitespace from ${name} value`)
+    process.env[name] = value.trim()
+  }
+}
+
 const msalConfig = {
   auth: {
     clientId: process.env.MSAL_CLIENT_ID,


### PR DESCRIPTION
## Summary
- warn if backend MSAL variables are missing
- trim extra whitespace in MSAL env vars
- document correct `.env` formatting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ffba09d98832ab7df3cad70412803