### PR TITLE
Implement mail logout endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ to build and start both containers. The frontend is available on
 [http://localhost:3000](http://localhost:3000). The current IP is displayed in
 the "Configure" link.
 
+The backend exposes a `/api/logout` endpoint that clears the mail widget
+authentication token so the next mail fetch will require logging in again.
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -99,6 +99,18 @@ app.get('/api/mails', async (req, res) => {
   }
 })
 
+app.post('/api/logout', (req, res) => {
+  accessToken = null
+  loginPromise = null
+  deviceCodeInfo = null
+  try {
+    pca.clearCache()
+  } catch (err) {
+    console.error('Failed to clear token cache', err)
+  }
+  res.json({ loggedIn: false })
+})
+
 app.get('/', (req, res) => {
   res.send('Backend running');
 });

--- a/dashboard/src/MailWidget.jsx
+++ b/dashboard/src/MailWidget.jsx
@@ -35,6 +35,12 @@ export default function MailWidget({ showBorder = true } = {}) {
     }
   }
 
+  async function handleLogout() {
+    await fetch('/api/logout', { method: 'POST' })
+    setMails(null)
+    setLoginInfo(null)
+  }
+
   useEffect(() => {
     fetchMails()
     const id = setInterval(fetchMails, 60000)
@@ -57,6 +63,9 @@ export default function MailWidget({ showBorder = true } = {}) {
 
   return (
     <div style={style}>
+      <button onClick={handleLogout} style={{ marginBottom: '4px' }}>
+        Logout
+      </button>
       <ul style={{ padding: 0, margin: 0, listStyle: 'none' }}>
         {mails.map((m) => (
           <li key={m.id} style={{ marginBottom: '4px' }}>


### PR DESCRIPTION
## Summary
- add logout support in backend
- expose logout button in MailWidget
- document `/api/logout` endpoint
- ignore node_modules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877af0692cc832a857ac591baf8779b