### PR TITLE
Fix MailWidget login error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+backend/node_modules/
+dashboard/node_modules/

--- a/backend/index.js
+++ b/backend/index.js
@@ -99,6 +99,18 @@ app.get('/api/mails', async (req, res) => {
   }
 })
 
+app.post('/api/logout', async (req, res) => {
+  accessToken = null
+  loginPromise = null
+  deviceCodeInfo = null
+  try {
+    await pca.getTokenCache().clear()
+  } catch (err) {
+    console.error('Failed to clear token cache', err)
+  }
+  res.json({ loggedOut: true })
+})
+
 app.get('/', (req, res) => {
   res.send('Backend running');
 });

--- a/dashboard/src/MailWidget.jsx
+++ b/dashboard/src/MailWidget.jsx
@@ -13,39 +13,45 @@ export default function MailWidget({ showBorder = true } = {}) {
     padding: '4px',
   }
 
+  async function startLogin() {
+    try {
+      const loginResp = await fetch('/api/login')
+      if (!loginResp.ok) throw new Error('login failed')
+      const data = await loginResp.json()
+      if (!data.loggedIn) {
+        if (!data.verificationUri || !data.userCode) {
+          throw new Error('login failed')
+        }
+        setLoginInfo(data)
+        setMails(null)
+        setError(null)
+        return
+      }
+      setLoginInfo(null)
+      setError(null)
+      return fetchMails()
+    } catch {
+      setLoginInfo(null)
+      setMails(null)
+      setError('Failed to start login')
+    }
+  }
+
   async function fetchMails() {
     try {
       const resp = await fetch('/api/mails')
-      if (resp.status === 401) {
-        try {
-          const loginResp = await fetch('/api/login')
-          if (!loginResp.ok) throw new Error('login failed')
-          const data = await loginResp.json()
-          if (!data.loggedIn) {
-            if (!data.verificationUri || !data.userCode) {
-              throw new Error('login failed')
-            }
-            setLoginInfo(data)
-            setMails(null)
-            setError(null)
-            return
-          }
-          setLoginInfo(null)
-          setError(null)
-          return fetchMails()
-        } catch {
-          setLoginInfo(null)
-          setMails(null)
-          setError('Failed to start login')
-          return
+      if (!resp.ok) {
+        if (resp.status === 401) {
+          return startLogin()
         }
+        throw new Error('mail fetch failed')
       }
       const data = await resp.json()
       setMails(data)
       setLoginInfo(null)
       setError(null)
     } catch {
-      setError('Failed to load mails')
+      startLogin()
     }
   }
 

--- a/dashboard/src/MailWidget.jsx
+++ b/dashboard/src/MailWidget.jsx
@@ -18,8 +18,16 @@ export default function MailWidget({ showBorder = true } = {}) {
       const resp = await fetch('/api/mails')
       if (resp.status === 401) {
         const loginResp = await fetch('/api/login')
+        if (!loginResp.ok) {
+          setError('Failed to start login')
+          return
+        }
         const data = await loginResp.json()
         if (!data.loggedIn) {
+          if (!data.verificationUri || !data.userCode) {
+            setError('Failed to start login')
+            return
+          }
           setLoginInfo(data)
           setMails(null)
           return


### PR DESCRIPTION
## Summary
- handle failed `/api/login` requests in MailWidget
- verify login information before displaying verification URL and device code

## Testing
- `npm install` in dashboard
- `npm run lint`
- `npm install` in backend

------
https://chatgpt.com/codex/tasks/task_e_6877cc128968832a92d0aeae7b684c5a