### PR TITLE
Add backend layout persistence

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,9 @@
 import express from 'express'
 import axios from 'axios'
 import { PublicClientApplication } from '@azure/msal-node'
+import { readFile, writeFile } from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 const msalConfig = {
   auth: {
@@ -10,6 +13,9 @@ const msalConfig = {
 }
 
 const pca = new PublicClientApplication(msalConfig)
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const layoutPath = path.join(__dirname, 'layout.json')
 
 let accessToken = null
 let loginPromise = null
@@ -74,7 +80,26 @@ async function fetchMails() {
   return data.value
 }
 
+async function loadLayoutFile() {
+  try {
+    const data = await readFile(layoutPath, 'utf8')
+    return JSON.parse(data)
+  } catch {
+    return null
+  }
+}
+
+async function saveLayoutFile(layout) {
+  try {
+    await writeFile(layoutPath, JSON.stringify(layout, null, 2), 'utf8')
+    return true
+  } catch {
+    return false
+  }
+}
+
 const app = express();
+app.use(express.json())
 const PORT = process.env.PORT || 3000;
 
 app.get('/api/public-ip', (req, res) => {
@@ -109,6 +134,22 @@ app.post('/api/logout', async (req, res) => {
     console.error('Failed to clear token cache', err)
   }
   res.json({ loggedOut: true })
+})
+
+app.get('/api/layout', async (req, res) => {
+  const layout = await loadLayoutFile()
+  if (layout) return res.json(layout)
+  res.status(404).json({ error: 'layout not found' })
+})
+
+app.post('/api/layout', async (req, res) => {
+  const layout = req.body
+  if (!layout || typeof layout !== 'object') {
+    return res.status(400).json({ error: 'invalid layout' })
+  }
+  const ok = await saveLayoutFile(layout)
+  if (ok) return res.json({ saved: true })
+  res.status(500).json({ error: 'failed to save layout' })
 })
 
 app.get('/', (req, res) => {

--- a/backend/layout.json
+++ b/backend/layout.json
@@ -1,0 +1,38 @@
+{
+  "type": "vertical",
+  "children": [
+    {
+      "type": "horizontal",
+      "children": [
+        { "type": "widget", "widget": "DateTimeWidget" },
+        { "type": "widget", "widget": "StringWidget", "props": { "text": "Hello from StringWidget" } }
+      ],
+      "style": { "flex": 1 }
+    },
+    {
+      "type": "horizontal",
+      "children": [
+        { "type": "widget", "widget": "TestWidget" },
+        { "type": "widget", "widget": "TestWidget" },
+        { "type": "widget", "widget": "TestWidget" }
+      ],
+      "style": { "flex": 1 }
+    },
+    {
+      "type": "horizontal",
+      "children": [
+        { "type": "widget", "widget": "TestWidget" },
+        { "type": "widget", "widget": "TestWidget" },
+        { "type": "widget", "widget": "TestWidget" }
+      ],
+      "style": { "flex": 1 }
+    },
+    {
+      "type": "horizontal",
+      "children": [
+        { "type": "widget", "widget": "MailWidget" }
+      ],
+      "style": { "flex": 1 }
+    }
+  ]
+}

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -41,9 +41,13 @@ function renderNode(node, index) {
 }
 
 function App() {
-  const layout = loadLayout()
+  const [layout, setLayout] = useState(null)
   const ip = window.PUBLIC_IP || 'unknown'
   const [backendIp, setBackendIp] = useState('...')
+
+  useEffect(() => {
+    loadLayout().then(setLayout)
+  }, [])
 
   useEffect(() => {
     fetch('/api/public-ip')
@@ -51,6 +55,7 @@ function App() {
       .then((d) => setBackendIp(d.ip))
       .catch(() => setBackendIp('error'))
   }, [])
+  if (!layout) return null
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
       {renderNode(layout)}

--- a/dashboard/src/ConfigPage.jsx
+++ b/dashboard/src/ConfigPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { loadLayout, saveLayout } from './layout.js'
 import { VerticalStackPanel, HorizontalStackPanel } from './StackPanels.jsx'
@@ -59,7 +59,11 @@ function removeAtPath(layout, path) {
 
 export default function ConfigPage() {
   const navigate = useNavigate()
-  const [layout, setLayout] = useState(loadLayout())
+  const [layout, setLayout] = useState(null)
+
+  useEffect(() => {
+    loadLayout().then(setLayout)
+  }, [])
 
   const allowDrop = (e) => e.preventDefault()
 
@@ -288,10 +292,10 @@ export default function ConfigPage() {
   }
 
   function handleSave() {
-    saveLayout(layout)
-    navigate('/')
+    saveLayout(layout).then(() => navigate('/'))
   }
 
+  if (!layout) return <div>Loading...</div>
   return (
     <div style={{ display: 'flex', height: '100%', padding: '1rem' }}>
       <div style={{ width: 150, marginRight: 10 }}>

--- a/dashboard/src/layout.js
+++ b/dashboard/src/layout.js
@@ -37,23 +37,27 @@ export const defaultLayout = {
   ]
 }
 
-export function loadLayout() {
+export async function loadLayout() {
   try {
-    const data = localStorage.getItem('layout')
-    if (data) {
-      return JSON.parse(data)
+    const resp = await fetch('/api/layout')
+    if (resp.ok) {
+      return await resp.json()
     }
   } catch (err) {
-    console.error('Failed to parse layout from localStorage', err)
+    console.error('Failed to load layout from backend', err)
   }
   return defaultLayout
 }
 
-export function saveLayout(layout) {
+export async function saveLayout(layout) {
   try {
-    localStorage.setItem('layout', JSON.stringify(layout))
+    await fetch('/api/layout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(layout),
+    })
   } catch (err) {
-    console.error('Failed to save layout', err)
+    console.error('Failed to save layout to backend', err)
   }
 }
 


### PR DESCRIPTION
## Summary
- store dashboard layout on the backend
- expose `/api/layout` GET and POST endpoints
- update frontend to load and save layout via backend

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878153c9778832a8fa20c5531c26823