### PR TITLE
Add mail body preview to MailWidget

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -73,7 +73,7 @@ async function ensureAccessToken() {
 async function fetchMails() {
   const token = await ensureAccessToken()
   const endpoint =
-    'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages?$top=5'
+    'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages?$top=5&$select=id,subject,bodyPreview,body'
   const { data } = await axios.get(endpoint, {
     headers: { Authorization: `Bearer ${token}` },
   })

--- a/dashboard/src/MailWidget.jsx
+++ b/dashboard/src/MailWidget.jsx
@@ -14,6 +14,15 @@ export default function MailWidget({ showBorder = true } = {}) {
     padding: '4px',
   }
 
+  const bodyStyle = {
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'pre-wrap',
+  }
+
   async function startLogin() {
     try {
       const loginResp = await fetch('/api/login')
@@ -83,6 +92,7 @@ export default function MailWidget({ showBorder = true } = {}) {
         {mails.map((m) => (
           <li key={m.id} style={{ marginBottom: '4px' }}>
             <strong>{m.subject}</strong>
+            <div style={bodyStyle}>{m.bodyPreview || m.body?.content || ''}</div>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- include body preview in MailWidget with CSS line clamp for two lines
- request body preview fields from backend API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a8a2013f8832a9aad6b572006efc9