### PR TITLE
Allow overriding kiosk user

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ to build and start both containers. The frontend is available on
 the "Configure" link.
 Use `kioskctl` to enable or disable the kiosk mode manually.
 
+The kiosk helper defaults to the `pi` user. Set the `KIOSK_USER` environment
+variable if your Raspberry Pi user has a different name.
+

--- a/kioskctl
+++ b/kioskctl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# kioskctl – enable / disable Chromium kiosk mode for the “pi” user
+# kioskctl – enable / disable Chromium kiosk mode for the Raspberry Pi user
+# Default user is "pi" but can be overridden via the KIOSK_USER environment variable.
 # Works on Raspberry\u00A0Pi\u00A0OS Bookworm (Wayland) and Bullseye (X11).
 #
 # Usage:
@@ -14,7 +15,7 @@ set -euo pipefail
 
 # ---------- configuration paths ----------
 CONF_FILE="/etc/kiosk.conf"                       # keeps only   URL=\"\u2026\"
-PI_USER="pi"                                      # change if you use another user
+PI_USER="${KIOSK_USER:-pi}"
 RUN_SCRIPT="/home/${PI_USER}/.local/bin/run-kiosk.sh"
 SERVICE_FILE="/home/${PI_USER}/.config/systemd/user/kiosk.service"
 LXDE_AUTOSTART="/home/${PI_USER}/.config/lxsession/LXDE-pi/autostart"

--- a/start_dashboard_pi.sh
+++ b/start_dashboard_pi.sh
@@ -13,4 +13,4 @@ docker compose up --build -d
 sleep 5
 
 # Enable kiosk mode to open the dashboard URL
-sudo ./kioskctl enable "http://localhost:8080"
+sudo KIOSK_USER=$USER ./kioskctl enable "http://localhost:8080"


### PR DESCRIPTION
## Summary
- support KIOSK_USER in `kioskctl`
- forward current user to kioskctl in `start_dashboard_pi.sh`
- document the override in the Raspberry Pi Kiosk section

## Testing
- `npm -C dashboard ci`
- `npm -C backend ci`
- `npm -C dashboard run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bf906ea1c832aaaf2c12da39851cd