### PR TITLE
Add VERSION arg to Dockerfiles and workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,6 +26,8 @@ jobs:
           context: ./dashboard
           file: ./dashboard/Dockerfile
           push: true
+          build-args: |
+            VERSION=${{ github.run_number }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/dashboard:latest
             ghcr.io/${{ github.repository_owner }}/dashboard:v${{ github.run_number }}
@@ -36,6 +38,8 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile
           push: true
+          build-args: |
+            VERSION=${{ github.run_number }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/backend:latest
             ghcr.io/${{ github.repository_owner }}/backend:v${{ github.run_number }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:20-alpine
+ARG VERSION
 
 # install CA roots once during build
 RUN apk add --no-cache ca-certificates && update-ca-certificates
@@ -7,6 +8,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install --omit=dev && npm cache clean --force
 COPY . .
+
+LABEL org.opencontainers.image.version=$VERSION
 
 EXPOSE 3000
 CMD ["npm","start"]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile for React (Vite) App
+ARG VERSION
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
@@ -7,10 +8,12 @@ RUN npm install && npm run build
 
 # Production stage
 FROM nginx:alpine
+ARG VERSION
 WORKDIR /usr/share/nginx/html
 COPY --from=build /app/dist .
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
+LABEL org.opencontainers.image.version=$VERSION
 EXPOSE 80
 CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- add `ARG VERSION` to Dockerfiles and label image version
- pass build argument from GitHub Actions using the run number

## Testing
- `npm install` in `dashboard`
- `npm run build` in `dashboard`
- `npm install` in `backend`
- `node index.js` in `backend` (terminated after startup)

------
https://chatgpt.com/codex/tasks/task_e_687cce1d7144832a9a69b9ecab20f5e2