### PR TITLE
Switch compose to GHCR images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # MyDashboard
 
 This project now consists of a React frontend and a small Express backend.
-Both services are built with Docker and orchestrated via `docker-compose`.
-The helper scripts start the compose stack while injecting the host's public IP
-address via the `PUBLIC_IP` environment variable.
+Both services are orchestrated via `docker-compose`.
+Prebuilt images are pulled from GitHub Container Registry, and the helper
+scripts start the stack while injecting the host's public IP address via the
+`PUBLIC_IP` environment variable.
 
 ## Usage
 
@@ -20,7 +21,14 @@ start_dashboard.bat
 ```
 
 Each script queries the public IP with `curl` and then runs `docker compose`
-to build and start both containers. The frontend is available on
+to start both containers. Use the `dev` profile if you want to rebuild the
+images locally:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile dev up --build
+```
+
+The frontend is available on
 [http://localhost:8080](http://localhost:8080) and the backend on
 [http://localhost:3000](http://localhost:3000). The current IP is displayed in
 the "Configure" link.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  frontend:
+    build: ./dashboard
+    profiles:
+      - dev
+  backend:
+    build: ./backend
+    profiles:
+      - dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '3.8'
+version: '3.9'
 services:
   frontend:
-    build: ./dashboard
+    image: ghcr.io/${OWNER}/dashboard-frontend
     environment:
       - PUBLIC_IP=192.168.2.35
  #    - PUBLIC_IP=${PUBLIC_IP}
@@ -10,7 +10,7 @@ services:
     depends_on:
       - backend
   backend:
-    build: ./backend
+    image: ghcr.io/${OWNER}/dashboard-backend
     environment:
       - NODE_OPTIONS=--dns-result-order=ipv4first
       - PUBLIC_IP=192.168.2.35

--- a/start_dashboard.bat
+++ b/start_dashboard.bat
@@ -5,5 +5,5 @@ REM Obtain public IP
 for /f "usebackq delims=" %%i in (`curl -s https://api.ipify.org`) do set PUBLIC_IP=%%i
 
 set PUBLIC_IP=%PUBLIC_IP%
-docker compose up --build
+docker compose up
 

--- a/start_dashboard.sh
+++ b/start_dashboard.sh
@@ -4,4 +4,4 @@ set -e
 # Obtain public IP
 PUBLIC_IP= 192.168.2.35 #$(curl -s https://api.ipify.org)
 export PUBLIC_IP
-exec docker compose up --build
+exec docker compose up


### PR DESCRIPTION
## Summary
- use GHCR images for the frontend and backend in docker-compose
- add a `docker-compose.dev.yml` with a `dev` profile for local builds
- update start scripts and README to reference the new workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cd017a3c8832ab1242f3185bb4605