### PR TITLE
docs: add GHCR login instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Prebuilt images are pulled from GitHub Container Registry, and the helper
 scripts start the stack while injecting the host's public IP address via the
 `PUBLIC_IP` environment variable.
 
+The Docker images referenced in the compose files live in GitHub Container
+Registry (GHCR) and may require authentication. Log in using your GitHub
+credentials before starting the stack:
+
+```bash
+echo <token> | docker login ghcr.io -u <github-username> --password-stdin
+```
+
+Make sure to run the helper script as the same user who performed the login
+(avoid `sudo` if possible).
+
 ## Usage
 
 ### Linux


### PR DESCRIPTION
## Summary
- explain that Docker images live in GHCR
- show how to login with a token
- clarify to avoid `sudo` when running scripts

## Testing
- `npm run lint` in `dashboard`
- `npm ci` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_687cdf4992e0832aabf9b315453b62c5