### PR TITLE
Add Watchtower auto-update service

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ to build and start both containers. The frontend is available on
 [http://localhost:3000](http://localhost:3000). The current IP is displayed in
 the "Configure" link.
 
+## Automatic Updates
+
+The compose stack now includes a [Watchtower](https://containrrr.dev/watchtower/)
+service that periodically checks for new container images and restarts the
+frontend and backend when updates are available.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "8080:80"
     depends_on:
       - backend
+
   backend:
     build: ./backend
     environment:
@@ -18,3 +19,15 @@ services:
     dns: 8.8.8.8
     ports:
       - "3000:3000"
+
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=300
+    restart: unless-stopped
+    depends_on:
+      - frontend
+      - backend


### PR DESCRIPTION
## Summary
- add Watchtower container to docker-compose
- document automatic updates via Watchtower

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688292d71940832a9c8674d17beb4235