### PR TITLE
Expose runtime version info

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,7 @@ RUN npm install --omit=dev && npm cache clean --force
 COPY . .
 
 LABEL org.opencontainers.image.version=$VERSION
+ENV VERSION=$VERSION
 
 EXPOSE 3000
 CMD ["npm","start"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -133,6 +133,10 @@ app.get('/api/public-ip', (req, res) => {
   res.json({ ip: process.env.PUBLIC_IP || 'unknown' });
 });
 
+app.get('/api/version', (req, res) => {
+  res.json({ version: process.env.VERSION || 'unknown' });
+});
+
 app.get('/api/login', async (req, res) => {
   try {
     const info = await startLogin()

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -15,5 +15,6 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 LABEL org.opencontainers.image.version=$VERSION
+ENV VERSION=$VERSION
 EXPOSE 80
 CMD ["/docker-entrypoint.sh"]

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -2,4 +2,6 @@
 set -e
 : "${PUBLIC_IP:=}"
 echo "window.PUBLIC_IP='${PUBLIC_IP}'" > /usr/share/nginx/html/env.js
+: "${VERSION:=unknown}"
+echo "window.VERSION='${VERSION}'" >> /usr/share/nginx/html/env.js
 exec nginx -g 'daemon off;'

--- a/dashboard/src/ConfigPage.jsx
+++ b/dashboard/src/ConfigPage.jsx
@@ -60,9 +60,11 @@ function removeAtPath(layout, path) {
 export default function ConfigPage() {
   const navigate = useNavigate()
   const [layout, setLayout] = useState(null)
+  const [version, setVersion] = useState('unknown')
 
   useEffect(() => {
     loadLayout().then(setLayout)
+    if (window.VERSION) setVersion(window.VERSION)
   }, [])
 
   const allowDrop = (e) => e.preventDefault()
@@ -329,6 +331,7 @@ export default function ConfigPage() {
         <button style={{ marginTop: '1rem' }} onClick={handleSave}>
           Save
         </button>
+        <div style={{ marginTop: '0.5rem' }}>Version: {version}</div>
       </div>
       <DropZone
         onDrop={(e) => handleDrop(e, [])}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/m4rvin42/dashboard:latest
     environment:
       - PUBLIC_IP=${PUBLIC_IP}
+      - VERSION=${VERSION:-unknown}
     ports:
       - "8080:80"
     depends_on:
@@ -12,6 +13,7 @@ services:
     environment:
       - NODE_OPTIONS=--dns-result-order=ipv4first
       - PUBLIC_IP=${PUBLIC_IP}
+      - VERSION=${VERSION:-unknown}
     dns: 8.8.8.8
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- expose environment version in Dockerfiles
- add version output to dashboard entrypoint
- display current version on ConfigPage
- expose `/api/version` on backend
- pass version variable through docker-compose

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68829bbee158832a85b557bf99dcfec4